### PR TITLE
fix: Include jinja templates directory and license in packaging configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,16 @@ classifiers =
 [options]
 package_dir = 
 	=.
+include_package_data = True
 packages = find:
 install_requires = 
 	python-apt
 	python-debian
 	jinja2
+license_files = LICENSE
+
+[options.package_data]
+cpc-sbom = templates/*.jinja2
 
 [options.entry_points]
 console_scripts = 


### PR DESCRIPTION
These were missing so unless you installed `--editable` from source the templates would not be found.

Addresses https://github.com/canonical/cpc-sbom/issues/10