### PR TITLE
Install required build dependencies for snap build when building in clean lxc container

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,7 @@ parts:
             - libapt-pkg-dev
             - gcc
             - g++
+            - dpkg-dev
         stage-packages:
             - libpython3.10-minimal
             - libpython3.10-stdlib


### PR DESCRIPTION
When using a clean lxc container to build snap these dependencies are not present. Add them explicitly.

* fix: Install dpkg-dev as build dependency

python-apt install uses the version of the deb package during install, To get this
it uses dpkg-parsechangelog which is part of the dpkg-dev package

* fix: Add g++ as snap build dependency

This fixes

```
x86_64-linux-gnu-gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
```

error during build

* fix: Add gcc as snap build dependency

This fixes

```
error: command 'x86_64-linux-gnu-gcc' failed: No such file or directory
```

error during build
