### PR TITLE
hotfix: Continue to support use of the __init__.py in cpc_sbom without using relative imports

### DIFF
--- a/cpc_sbom/__init__.py
+++ b/cpc_sbom/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from .generate import generate_sbom
+from generate import generate_sbom
 
 CPC_SBOM_VERSION = "0.1.8"
 


### PR DESCRIPTION
This fixes the following error when __init__.py called directly.

```
Traceback (most recent call last):
  File "/build/config/hooks.d/extra/sbom-tools/__init__.py", line 2, in <module>
    from .generate import generate_sbom
ImportError: attempted relative import with no known parent package
```