### PR TITLE
fix: Resolve relative import issues when run as snap command

### DIFF
--- a/cpc_sbom/__init__.py
+++ b/cpc_sbom/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-from generate import generate_sbom
-
 CPC_SBOM_VERSION = "0.1.10"
 
 if __name__ == "__main__":
+    from generate import generate_sbom
     generate_sbom()


### PR DESCRIPTION
When running cpc-sbom command as a snap error

```
19:09:46   File "/snap/cpc-sbom/x1/lib/python3.10/site-packages/cpc_sbom/__init__.py", line 2, in <module>
19:09:46     from generate import generate_sbom
```

was encountered. Changing to only import from `generate` when required solved the problem