### PR TITLE
fix: pin python-debian requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 python_requires= >=3.8
 install_requires = 
 	python-apt @ git+https://salsa.debian.org/apt-team/python-apt.git@main#egg=python-apt
-	python-debian @ git+https://salsa.debian.org/python-debian-team/python-debian.git@master#egg=python-debian
+	python-debian @ git+https://salsa.debian.org/python-debian-team/python-debian.git@0.1.49#egg=python-debian
 	jinja2
 license_files = LICENSE
 


### PR DESCRIPTION
Commit 09fb3fbc upstream moved all build configuration for python-debian to pyproject.toml, causing the snap builds to fail.