### PR TITLE
fix: Add support for earlier python_apt versions and python 3.5 support

### DIFF
--- a/cpc_sbom/generate.py
+++ b/cpc_sbom/generate.py
@@ -268,7 +268,7 @@ def _get_package_licenses(
     return package_licenses
 
 
-def _get_package_url(package_installed: Optional[apt.Version]) -> str:
+def _get_package_url(package_installed: Optional[apt.package.Version]) -> str:
     """
     Gets the package origin URL. This is used as the download location and is also
     part of the reference locator.

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package_dir =
 	=.
 include_package_data = True
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.5
 install_requires = 
 	python-apt @ git+https://salsa.debian.org/apt-team/python-apt.git@main#egg=python-apt
 	python-debian @ git+https://salsa.debian.org/python-debian-team/python-debian.git@0.1.49#egg=python-debian


### PR DESCRIPTION
This allows SBOMs to be built on Ubuntu 16.04 where python 3.5 is the default python3 env and python_apt version 1.1.0b1+ubuntu0.16.4.12 is the default.

apt.package.Version is available across all python-apt versions shipped in Ubuntu but apt.Version is only available in newer versions.