### PR TITLE
ci: fix snap asset file name

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -54,5 +54,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ${{ steps.build-snap.outputs.snap }}
-          asset_name: cpc-sbom-${{ steps.latest_tag.outputs.LATEST_TAG }}.snap.zip
-          asset_content_type: application/zip
+          asset_name: cpc-sbom-${{ steps.latest_tag.outputs.LATEST_TAG }}.snap
+          asset_content_type: application/vnd.snap


### PR DESCRIPTION
The uploaded snap package asset isn't actually a zip file.

For example:
```
$ unzip -t cpc-sbom-v0.1.15.snap.zip 
Archive:  cpc-sbom-v0.1.15.snap.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of cpc-sbom-v0.1.15.snap.zip or
        cpc-sbom-v0.1.15.snap.zip.zip, and cannot find cpc-sbom-v0.1.15.snap.zip.ZIP, period.
```

I wasn't able to test this on my repo (`The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings.`)

Thus, I propose to set the appropriate name and MIME type on the GitHub worflow.

Not sure about the appropriate MIME type but Freedesktop uses `application/vnd.snap` (https://cgit.freedesktop.org/xdg/shared-mime-info/commit/?id=4882ca0ca00bba68d8d8ddaf43dc486634c35043)