### PR TITLE
fix: Pin python-apt version to known working version 2.4.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.5
 install_requires = 
-	python-apt @ git+https://salsa.debian.org/apt-team/python-apt.git@main#egg=python-apt
+	python-apt @ git+https://salsa.debian.org/apt-team/python-apt.git@2.4.y#egg=python-apt
 	python-debian @ git+https://salsa.debian.org/python-debian-team/python-debian.git@0.1.49#egg=python-debian
 	jinja2
 license_files = LICENSE


### PR DESCRIPTION
Following a release of python-apt 2.7.6 there is now a requirement on `libapt-pkg-dev Build-Depends to >= 2.7.11~.`

This is only available on Ubutnu 24.04 or later.

As such we pin to a known working and support branch `2.4.*` which is the version being maintained in Ubuntu 22.04.