### PR TITLE
feat: add security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Only the main branch of this repo and the corresponding edge release of the
+cpc-sbom snap are supported.
+
+## What qualifies as a security issue
+
+Any issue which affects the confidentiality, integrity, or availability of
+information, systems, or users using this tool should be reported.
+
+## Reporting a Vulnerability
+To report a security issue, file a
+[Private Security Report](https://github.com/Canonical/cpc-sbom/security/advisories/new)
+with a description of the issue, the steps you took to create the issue,
+affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+contains more information about what you can expect when you contact us and
+what we expect from you.


### PR DESCRIPTION
Adding the security.md to improve the repo's security advisory posture and comply with best practices.