### PR TITLE
test: enable testing for python 3.12 and 3.13

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ["3.8.10", "3.10", "3.11"]
+        python: ["3.8.10", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
To have coverage on those newer versions, too.